### PR TITLE
Fixes out-of-sync TTLs after running decr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ Limiter.prototype.get = function (fn) {
     var n = ~~res[0];
     var max = ~~res[1];
     var ex = ~~res[2];
+    var dateNow = Date.now();
 
     if (n <= 0) return done();
 
@@ -103,7 +104,9 @@ Limiter.prototype.get = function (fn) {
     }
 
     db.multi()
-      .set([count, n - 1, 'PX', ex * 1000 - Date.now(), 'XX'])
+      .set([count, n - 1, 'PX', ex * 1000 - dateNow, 'XX'])
+      .pexpire([limit, ex * 1000 - dateNow])
+      .pexpire([reset, ex * 1000 - dateNow])
       .exec(function (err, res) {
         if (err) return fn(err);
         if (isFirstReplyNull(res)) return mget();


### PR DESCRIPTION
Thanks for a great module! I would like to contribute a fix & test related to TTLs that run out of sync when the decr() function updates the count, leaving it with a different TTL than limit & reset.