### PR TITLE
Add duration in microseconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ Limiter.prototype.get = function (fn) {
       var oldest = parseInt(Array.isArray(res[0]) ? res[3][1] : res[3]);
       fn(null, {
         remaining: count < max ? max - count : 0,
-        reset: Math.floor((oldest + duration) / 1000000),
+        reset: Math.floor((oldest + duration * 1000) / 1000000),
         total: max
       });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -64,7 +64,7 @@ var Limiter = require('..'),
         });
         limit.get(function(err, res) {
           var left = res.reset - (Date.now() / 1000);
-          left.should.be.below(60);
+          left.should.be.below(60).and.be.greaterThan(0);
           done();
         });
       });


### PR DESCRIPTION
`oldest` is in microseconds and `duration` in milliseconds. I think they should be in the same units.