### PR TITLE
Return accurate reset time for each limited call

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -113,17 +113,18 @@ var Limiter = require('..'),
       });
 
       it('should return an increasing reset time after each call', function (done) {
-        var originalResetMs;
-        limit.get(function(err, res) {
-          originalResetMs = res.resetMs;
+        setTimeout(function () {
+          limit.get(function(err, res) {
+            var originalResetMs = res.resetMs;
 
-          setTimeout(function() {
-            limit.get(function (err, res) {
-              res.resetMs.should.be.greaterThan(originalResetMs);
-              done();
-            });
-          }, 200);
-        });
+            setTimeout(function() {
+              limit.get(function (err, res) {
+                res.resetMs.should.be.greaterThan(originalResetMs);
+                done();
+              });
+            }, 10);
+          });
+        }, 10);
       });
     });
 


### PR DESCRIPTION
Since the rate limit strategy saves all the calls in Redis, the reset time returned needs to depend on the oldest call in the range of the limiter.
In practice, the oldest call to use to calculate the reset time is the max-th element from the end or the first element of the sorted set.

Closes #43.