### PR TITLE
Remove splice operation

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,10 +69,10 @@ Limiter.prototype.get = function (fn) {
     ['zadd', key, now, now],
     ['zrange', key, 0, 0],
     ['zrange', key, -max, -max],
+    ['zremrangebyrank', key, 0, -(max + 1)],
     ['pexpire', key, duration],
   ]
-  
-  operations.splice(5, 0, ['zremrangebyrank', key, 0, -(max + 1)])
+
   db.multi(operations)
     .exec(function (err, res) {
       if (err) return fn(err);


### PR DESCRIPTION
The `.splice()` was necessary when the `tidy` option was
available. But since b958870, `zremrangebyrank` is always run,
so it can live in the `operations` array by default.

This is just a minor cleanup commit. 